### PR TITLE
Add linux kernel module link to implementations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Here are libraries that allow I2C interaction with the boards running this softw
 - [Arduino](https://github.com/solderparty/arduino_bbq10kbd)
 - [CircuitPython](https://github.com/solderparty/arturo182_CircuitPython_BBQ10Keyboard)
 - [Rust (Embedded-HAL)](https://crates.io/crates/bbq10kbd)
+- [Linux Kernel Module](https://github.com/billylindeman/bbq10kbd-kernel-driver)
 
 ## Protocol
 


### PR DESCRIPTION
I've built a linux kernel module for the bbq20 keyboard (using the i2c interface) and wanted to add a reference to it.  
